### PR TITLE
Support Swoole 5

### DIFF
--- a/src/Server.php
+++ b/src/Server.php
@@ -200,7 +200,7 @@ class Server extends Socket
         $response->status(101);
         $response->end();
 
-        $this->server->defer(function () use ($socket) {
+        \Swoole\Event::defer(function () use ($socket) {
             $this->socketManager->add($socket);
             call_user_func($this->server->getCallback('Open'), $this->server, $socket);
         });


### PR DESCRIPTION
Swoole 5 support. The Swoole\Server->defer method is an alias for Swoole\Event::defer and was removed in Swoole 5.